### PR TITLE
feat: add `createRootOptions` to `ComponentRenderOptions`

### DIFF
--- a/src/pure.tsx
+++ b/src/pure.tsx
@@ -256,7 +256,7 @@ interface ReactRoot {
   unmount: () => void
 }
 
-function createConcurrentRoot(container: HTMLElement, options?: RootOptions): ReactRoot {
+function createConcurrentRoot(container: HTMLElement, options: RootOptions | undefined): ReactRoot {
   const root = ReactDOMClient.createRoot(container, options)
 
   return {

--- a/src/pure.tsx
+++ b/src/pure.tsx
@@ -64,6 +64,11 @@ export interface ComponentRenderOptions {
   container?: HTMLElement
   baseElement?: HTMLElement
   wrapper?: React.JSXElementConstructor<{ children: React.ReactNode }>
+  /**
+   * Options passed to React's `createRoot`.
+   *
+   * @see {@link https://react.dev/reference/react-dom/client/createRoot API Reference for `createRoot`}
+   */
   createRootOptions?: RootOptions
 }
 

--- a/src/pure.tsx
+++ b/src/pure.tsx
@@ -1,7 +1,7 @@
 import type { Locator, LocatorSelectors, PrettyDOMOptions } from 'vitest/browser'
 import { page, server, utils } from 'vitest/browser'
 import React from 'react'
-import type { Container } from 'react-dom/client'
+import type { Container, RootOptions } from 'react-dom/client'
 import ReactDOMClient from 'react-dom/client'
 
 const { debug, getElementLocatorSelectors } = utils
@@ -64,6 +64,7 @@ export interface ComponentRenderOptions {
   container?: HTMLElement
   baseElement?: HTMLElement
   wrapper?: React.JSXElementConstructor<{ children: React.ReactNode }>
+  createRootOptions?: RootOptions
 }
 
 export interface RenderOptions extends ComponentRenderOptions {}
@@ -82,7 +83,7 @@ const mountedRootEntries: {
  */
 export async function render(
   ui: React.ReactNode,
-  { container, baseElement, wrapper: WrapperComponent }: ComponentRenderOptions = {},
+  { container, baseElement, wrapper: WrapperComponent, createRootOptions }: RenderOptions = {},
 ): Promise<RenderResult> {
   if (!baseElement) {
     // default to document.body instead of documentElement to avoid output of potentially-large
@@ -102,7 +103,7 @@ export async function render(
   let root: ReactRoot
 
   if (!mountedContainers.has(container)) {
-    root = createConcurrentRoot(container)
+    root = createConcurrentRoot(container, createRootOptions)
 
     mountedRootEntries.push({ container, root })
     // we'll add it to the mounted containers regardless of whether it's actually
@@ -250,8 +251,8 @@ interface ReactRoot {
   unmount: () => void
 }
 
-function createConcurrentRoot(container: HTMLElement): ReactRoot {
-  const root = ReactDOMClient.createRoot(container)
+function createConcurrentRoot(container: HTMLElement, options?: RootOptions): ReactRoot {
+  const root = ReactDOMClient.createRoot(container, options)
 
   return {
     render(element: React.ReactNode) {

--- a/test/fixtures/RenderId.tsx
+++ b/test/fixtures/RenderId.tsx
@@ -1,0 +1,5 @@
+import { useId } from 'react'
+
+export function RenderId(): React.ReactNode {
+  return useId()
+}

--- a/test/render.test.tsx
+++ b/test/render.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'vitest-browser-react'
 import { HelloWorld } from './fixtures/HelloWorld'
 import { Counter } from './fixtures/Counter'
 import { SuspendedHelloWorld } from './fixtures/SuspendedHelloWorld'
+import { RenderId } from './fixtures/RenderId'
 
 test('renders simple component', async () => {
   const screen = await render(<HelloWorld />)
@@ -66,4 +67,14 @@ test('trace mark', async () => {
 
   await screen.unmount()
   expect(screen.container.innerHTML).toBe('')
+})
+
+test('passes createRootOptions to createRoot', async () => {
+  const identifierPrefix = 'my-custom-id-prefix'
+
+  const screen = await render(<RenderId />, {
+    createRootOptions: { identifierPrefix },
+  })
+
+  expect(screen.container).toHaveTextContent(identifierPrefix)
 })


### PR DESCRIPTION
This allows passing options to React's `createRoot`

closes #52